### PR TITLE
Fixing some type declaration issues

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -6,6 +6,7 @@ import WalletTypeSelector from './walletTypeSelector'
 import { ProtonWebLink } from './links/protonWeb'
 import { Storage } from './storage'
 import { WALLET_TYPES } from './constants'
+import { ConnectWalletArgs, ConnectWalletRet, SelectorOptions, LocalLinkOptions } from './types'
 
 export const ConnectWallet = async ({
   linkOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,7 @@ import { ConnectWallet } from './connect'
 export type { ProtonWebLink } from './links/protonWeb'
 export type { Link, LinkSession, TransactResult } from '@proton/link'
 
+//Allowing Type Definitions to be used by other modules
+export * from "./types"
+
 export default ConnectWallet

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,3 +1,5 @@
+import { CustomStyleOptions } from ".";
+
 export default (customStyleOptions: CustomStyleOptions | undefined): string => {
     const defaultOptions = {
         modalBackgroundColor: '#ffffff',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
+import {LinkStorage, LinkOptions, LinkSession, Link, LoginResult} from "@proton/link"
+import { BrowserTransportOptions } from "@proton/browser-transport"
+import { ProtonWebLink } from './links/protonWeb';
+
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
-interface CustomStyleOptions {
+export interface CustomStyleOptions {
   modalBackgroundColor?: string,
   logoBackgroundColor?: string,
   isLogoRound?: boolean,
@@ -11,7 +15,7 @@ interface CustomStyleOptions {
   linkColor?: string,
 }
 
-interface SelectorOptions {
+export interface SelectorOptions {
     appName?: string,
     appLogo?: string,
     walletType?: string,
@@ -19,7 +23,7 @@ interface SelectorOptions {
     customStyleOptions?: CustomStyleOptions
 }
 
-type LocalLinkOptions = PartialBy<LinkOptions, 'transport'|'chains'|'scheme'> & {
+export type LocalLinkOptions = PartialBy<LinkOptions, 'transport'|'chains'|'scheme'> & {
   endpoints: string[],
   storage?: LinkStorage,
   storagePrefix?: string,
@@ -27,13 +31,13 @@ type LocalLinkOptions = PartialBy<LinkOptions, 'transport'|'chains'|'scheme'> & 
   testUrl?: string
 }
 
-interface ConnectWalletArgs {
+export interface ConnectWalletArgs {
   linkOptions: LocalLinkOptions,
   transportOptions?: BrowserTransportOptions;
   selectorOptions?: SelectorOptions
 }
 
-interface ConnectWalletRet {
+export interface ConnectWalletRet {
   session?: LinkSession;
   link?: ProtonWebLink | Link;
   loginResult?: LoginResult;

--- a/src/walletTypeSelector.ts
+++ b/src/walletTypeSelector.ts
@@ -1,4 +1,5 @@
 import getStyleText from './styles'
+import { CustomStyleOptions } from '.';
 
 export default class WalletTypeSelector {
     constructor(public readonly name?: string, logo?: string, customStyleOptions?: CustomStyleOptions) {


### PR DESCRIPTION
Upon downloading the web-sdk, there appeared to be some issues with typings and declarations used throughout the module that kept the module from compiling. I believe that moving these used type declarations from a declaration file to an actual types.ts file would solve these issues, along with exporting the types defined in the web-sdk module so they can be used elsewhere.