### PR TITLE
add identity proof to session metadata

### DIFF
--- a/packages/proton-link/src/link.ts
+++ b/packages/proton-link/src/link.ts
@@ -591,6 +591,8 @@ export class Link {
             },
         })
         const metadata = sessionMetadata(res.payload, res.resolved.request)
+        // add the identity proof represented as 'EOSIO <hash>' to metadata
+        metadata['identityProof'] = String(res.proof)
         const signerKey = res.proof.recover()
         let session: LinkSession
 


### PR DESCRIPTION
Updated links.ts
Add identity proof metadata to make it accessible within the session. This can be transferred (securely) to an arbitrary backend service which then can validate the proof analogous to [greymass/idproofer](https://github.com/greymass/idproofer/blob/master/src/app.ts).