### PR TITLE
Android enhancement intent and webView fixes

### DIFF
--- a/packages/proton-browser-transport/src/utils.ts
+++ b/packages/proton-browser-transport/src/utils.ts
@@ -81,27 +81,27 @@ export function generateReturnUrl() {
     }
 
     if (isAndroid() && isFirefox()) {
-        return 'android-intent://org.mozilla.firefox'
+        return 'android-app://org.mozilla.firefox'
     }
 
     if (isAndroid() && isEdge()) {
-        return 'android-intent://com.microsoft.emmx'
+        return 'android-app://com.microsoft.emmx'
     }
 
     if (isAndroid() && isOpera()) {
-        return 'android-intent://com.opera.browser'
+        return 'android-app://com.opera.browser'
     }
 
     if (isAndroid() && isBrave()) {
-        return 'android-intent://com.brave.browser'
+        return 'android-app://com.brave.browser'
     }
 
     if (isAndroid() && isAndroidWebView()) {
-        return 'android-intent://webview'
+        return 'android-app://webview'
     }
 
     if (isAndroid() && isChromeMobile()) {
-        return 'android-intent://com.android.chrome'
+        return 'android-app://com.android.chrome'
     }
 
     return window.location.href

--- a/packages/proton-browser-transport/src/utils.ts
+++ b/packages/proton-browser-transport/src/utils.ts
@@ -46,8 +46,11 @@ export function isAndroid() {
     return /Android/.test(navigator.userAgent)
 }
 
+// @ts-ignore
+export const isNativeApp = () => !!window.ReactNativeWebView;
+
 export function isAndroidWebView() {
-    return /wv/.test(navigator.userAgent) || /Android.*AppleWebKit/.test(navigator.userAgent);
+    return /wv/.test(navigator.userAgent) || (/Android/.test(navigator.userAgent) && isNativeApp());
 }
 
 export function isMobile() {


### PR DESCRIPTION
**1. Fix `ReturnUrl` schema for android intents**

 This commit addresses the issue with the ReturnUrl schema. The change is necessary due to the usage of URI syntax for intents in Android, specifically `android-intent://${packageName}`. However, I encounter an issue as React Native does not provide direct support for sending Intents using this URI syntax. Therefore, the workaround adopted is to use `android-app://${packageName}`, which effectively resolves the issue and ensures proper functionality.



**2. Refine Android WebView detection regex**

This commit addresses an issue with the previous regex used in the `isAndroidWebView` function. The regex `/Android.*AppleWebKit/` for checking the presence of WebView in Android was problematic, as the user agent string of the mobile Chrome browser also includes AppleWebKit. This led to incorrect identification of WebView when used by a mobile Chrome browser.

To resolve this, the regex was replaced with a more accurate approach. Now, the function checks for the presence of 'wv' in the user agent or, if the user agent contains 'android' and the app is recognized as a React Native WebView app (using the `isNativeApp` function), it correctly identifies Android WebView.